### PR TITLE
fix: container name parsing in Docker Swarm env

### DIFF
--- a/docker_events.sh
+++ b/docker_events.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Absolute or relative path to the user defined scripts. It is usually the script directory.
 : "${scripts_dir:=.}"
@@ -58,7 +58,7 @@ service() {
             echo Event has been catched: $name
 
             # check for container labels fist
-            coname=$(echo $name | cut -d. -f2)
+			coname="${name#*.}"
             
             # skip ourself events
             [[ "$coname" == "$selfconame" ]] && continue


### PR DESCRIPTION
fix: container name parsing in Docker Swarm env

- Change shebang from sh to bash for better feature support
- Replace cut command with bash parameter expansion for container name parsing
- Support Swarm service docker name notation "[stack_name]_[service_name].[task_slot].[random_slug]" which contains several dots

Swarm container name example: `portainer_edge_agent.79f6tnuckafxbmag9ux9hs7zf.3i6mqyj0jjmua9ze2o7gr5zr6`